### PR TITLE
feat: support custom handler for "open in editor"

### DIFF
--- a/app/views/loc-badge.js
+++ b/app/views/loc-badge.js
@@ -3,5 +3,9 @@ discovery.view.define('loc-badge', {
     className: 'function-loc',
     data: 'function or $ | marker("function").object |? { ..., text: loc }',
     whenData: 'text',
-    content: 'html:text.split(/:/).join(`<span class="delim">:</span>`)'
+    content: 'html:text.split(/:/).join(`<span class="delim">:</span>`)',
+    postRender(el, _, data) {
+        // Support a injectable custom function to provide custom action to open in editor
+        window.handleOpenInEditor?.(el, data.module.path + data.text);
+    }
 }, { tag: false });


### PR DESCRIPTION
Thank you for this awesome project! It's really helpful!

The only thing I found a bit tedious was locating the exact line of the functions that we were inspecting. Having a "open in editor" feature would be greatly helpful to the overall workflow.

While this could be a bit tricky to do due to the the web being by nature sandboxed, and depending on what context it runs, it might have a different approach to link to the local file. To make it easy to extend and suitable for different scenarios, I think providing an injectable "handler" function would be the best fit, while later we could figure out a better default handling.

I built [a VS Code extension for open `.cpuprofile` with cpupro](https://github.com/antfu/vscode-cpupro), and I want it to be able to redirect me directly to the code. I used a local patched version of cpupro, and here is what I have:

https://github.com/lahmatiy/cpupro/assets/11247099/950a72cd-7cdd-4600-bbc9-fe697dd7a297

And here is how I am doing it: https://github.com/antfu/vscode-cpupro/blob/798dcc5a6f07128a420a5caeeec9c7322fd9a261/src/index.ts#L54-L63

(off topic, that I also made https://github.com/localfile-link/localfile-link to allow opening editor from any website, via a client app handle the custom protocol, similar to how Zoom link works - if you are interested in it, I'd be happy to discuss about how we could integrate that for the web version)