### PR TITLE
let browser use dark color scheme for scrollbars

### DIFF
--- a/app/pages/common.css
+++ b/app/pages/common.css
@@ -13,6 +13,7 @@
 }
 .discovery-root-darkmode {
     --runtime-unknown: url("../img/runtime-v8-outline.svg");
+    color-scheme: dark;
 }
 
 .view-alert-warning .view-link {


### PR DESCRIPTION
Use dark color scheme, also for scrollbars, by defining dark color-scheme.

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/bd7a266e-2437-4f12-8f4c-b8a4012628f2) | ![after](https://github.com/user-attachments/assets/c874f194-a267-4b8e-8d1a-b4c95de8196f) |

tested change with css developer tools in chromium